### PR TITLE
fixing typo in calculation of pi_hat_se

### DIFF
--- a/chp02/monte_carlo_pi.py
+++ b/chp02/monte_carlo_pi.py
@@ -16,7 +16,7 @@ def pi_est(radius=1, num_iter=int(1e4)):
     
     I_hat = np.mean(samples)
     pi_hat = I_hat/radius ** 2
-    pi_hat_se = np.std(samples)/np.sqrt(num_iter)    
+    pi_hat_se = np.std(samples)/np.sqrt(num_iter)/radius ** 2
     print("pi est: {} +/- {:f}".format(pi_hat, pi_hat_se))
     
     plt.figure()


### PR DESCRIPTION
Sorry, I could be wrong, but it seems to be a typo in the calculation:

now: 
pi est: 3.1348 +/- 0.016469 (radius 1)
pi est: 3.1348 +/- 6.587538  (radius 20)
pi est: 3.1348 +/- 164.688462 (radius 100)

candidate:
pi est: 3.1348 +/- 0.016469 (radius 1)
pi est: 3.1348 +/- 0.016469 (radius 20)
pi est: 3.1348 +/- 0.016469 (radius 100)
